### PR TITLE
Update bezier-curve-editor-view.coffee

### DIFF
--- a/lib/bezier-curve-editor-view.coffee
+++ b/lib/bezier-curve-editor-view.coffee
@@ -75,7 +75,7 @@ class BezierCurveEditorView extends View
     offset = $view.offset()
     gutterWidth = $view.find('.gutter').width()
 
-    top = position.top + view.lineHeight + 15
+    top = position.top + 15
     left = position.left + gutterWidth - @width() / 2
 
     if top + @height() > @parents('.scroll-view').find('.underlayer').height()


### PR DESCRIPTION
（日本語で失礼します）
bezier-curve-editerのUIがエディタ範囲の上に表示されてしまう（cssのtopプロパティが設定されない）ようだったので、修正しました。
